### PR TITLE
add manual instructions for project cloning to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,15 @@
 
 ### Clone project
 
-    curl https://raw.githubusercontent.com/poscaster/backend/master/scripts/clone.sh | bash
+    curl https://raw.githubusercontent.com/poscaster/backend/master/scripts/clone.sh | sudo bash
+
+or
+
+    mkdir poscaster
+    cd poscaster
+
+    git clone git@github.com:poscaster/backend.git
+    git clone git@github.com:poscaster/frontend.git
 
 ### Run
 

--- a/scripts/clone.sh
+++ b/scripts/clone.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+if [ "$EUID" -eq 0 ]; then
+   echo "You have just launched script from unknown source as a root without even looking what it does."
+   echo "For what it worth we might be compromising your system right now."
+   echo "Please, consider your safety. Further reading: http://tserong.github.io/sudo-wget/, https://www.seancassidy.me/dont-pipe-to-your-shell.html"
+   echo "(Once you are condifent with this script, just re-run it as user)"
+   exit 1
+fi
+
 set -e
 
 mkdir poscaster


### PR DESCRIPTION
replace initial instructions with even more ridiculous `curl ... | sudo
bash`

detect when someone actually runs script as a root and print a warning
to them - maybe the won't do it next time